### PR TITLE
Fix num of cols in countries markdown table

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,12 +29,12 @@ This repository aims to simplify this by mapping the ecosystem of guidelines, pr
 
 ### National Regulation by Economic Area
 
-| | | |
-|-|-|-|
+| | | | |
+|-|-|-|-|
 |[Austria 🇦🇹](#austria)|[Brazil 🇧🇷](#brazil)|[Canada 🇨🇦](#canada)|[China 🇨🇳](#china)|
 |[Dubai 🇦🇪](#dubai)|[European Union 🇪🇺](#european-union)|[India 🇮🇳](#india)|[Ireland 🇮🇪](#ireland)|
 |[Israel 🇮🇱](#israel)|[Mexico 🇲🇽](#mexico)|[Singapore 🇸🇬](#singapore)|[Switzerland 🇨🇭](#switzerland)|
-|[United Arab Emirates 🇦🇪](#united-arab-emirates)|[United Kingdom 🇬🇧](#united-kingdom)|[United States of America 🇺🇸](#united-states-of-america)||
+|[United Arab Emirates 🇦🇪](#united-arab-emirates)|[United Kingdom 🇬🇧](#united-kingdom)|[United States of America 🇺🇸](#united-states-of-america)|
 
 ### Other Sections
 


### PR DESCRIPTION
One column is missing in countries markdown table right now, due to which only 12 out of 15 countries are visible in rendered markdown table [here](https://github.com/EthicalML/awesome-artificial-intelligence-regulation#national-regulation-by-economic-area).

This PR adds the missing column so all countries are visible properly, preview [here](https://github.com/omkar-foss/awesome-artificial-intelligence-regulation/tree/fix-countries-table#national-regulation-by-economic-area). Additionally, also removes extra trailing `|` at end of same markdown table.