### PR TITLE
Add AI Laws by State (50-state AI legislation tracker)

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,7 @@ This repository aims to simplify this by mapping the ecosystem of guidelines, pr
 
 ## United States of America
 
+* [AI Laws by State](https://www.ailawsbystate.com) - Free 50-state tracker for U.S. artificial intelligence legislation, sourced from primary state legislature feeds. Covers bill status, effective dates, penalty structures, and topic categorization (deepfakes, hiring, healthcare AI, disclosure, bias audits).
 * [California Consumer Privacy Act (CCPA)](http://leginfo.legislature.ca.gov/faces/billCompareClient.xhtml?bill_id=201720180AB375) - Legal text for California's consumer privacy act
 * [DoD's Ethical Principles for AI](https://www.diu.mil/responsible-ai-guidelines) - The U.S.A. Department of Defense responsible AI guidelines for tech contractors. The guidelines provide a step-by-step process to follow during the planning, development, and deployment phases of the technical lifecycle.
 * [EU-U.S. and Swiss-U.S. Privacy Shield Frameworks](https://www.privacyshield.gov/welcome) - The EU-U.S. and Swiss-U.S. Privacy Shield Frameworks were designed by the U.S. Department of Commerce and the European Commission and Swiss Administration to provide companies on both sides of the Atlantic with a mechanism to comply with data protection requirements when transferring personal data from the European Union and Switzerland to the United States in support of transatlantic commerce.


### PR DESCRIPTION
This adds [AI Laws by State](https://www.ailawsbystate.com), a free 50-state tracker for U.S. AI legislation that covers:

- Bill status, effective dates, and penalty structures across all 50 states
- Topic-specific trackers (deepfakes, hiring, healthcare AI, disclosure, bias audits)
- Primary-source linked — every entry cites the official state legislature URL
- Free tier covers state pages, bill detail, and basic search; Pro tier for CSV exports, alerts, comparison tools, and full historical data

Fits in the **United States of America** section under *Regulation and Policy* because it is a comprehensive open tracker for state-level AI legislation — a resource practitioners, researchers, and policymakers working on U.S. AI regulation will find valuable.

Happy to adjust formatting or section placement to match your conventions.